### PR TITLE
Generate links and QR for user after_save instead of after_create.

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -32,6 +32,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     user = User.from_omniauth(auth)
     if user.present?
       sign_out_all_scopes
+      GenerateLinksForNewUser.new(user).call
+      GenerateQrCodeForUser.new(user).call
       flash[:success] = t 'devise.omniauth_callbacks.success', kind: 'Google'
       sign_in_and_redirect user, event: :authentication
     else

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -10,9 +10,16 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   # POST /resource
-  # def create
-  #   super
-  # end
+  def create
+    super
+
+    if resource.save!
+      GenerateLinksForNewUser.new(resource).call
+      GenerateQrCodeForUser.new(resource).call
+    else
+      redirect_to new_user_registration_path
+    end
+  end
 
   # GET /resource/edit
   def edit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,9 +14,6 @@ class User < ApplicationRecord
 
   friendly_id :username, use: %i[slugged]
 
-  after_save :create_default_links, :generate_qr_code
-  after_update :create_default_links
-
   validates :full_name, length: { maximum: 64 }
   validates :description, length: { maximum: 256 }
   validates_format_of :username, :with => /\A[a-z0-9]+\z/i
@@ -40,87 +37,5 @@ class User < ApplicationRecord
       user.full_name = auth.info.name
       user.avatar_url = auth.info.image
     end
-  end
-
-  private
-
-  def create_default_links
-    if self.links.count == 0
-      # Create default group
-      default_group = Group.create(name: "My Links")
-      # Creates 5 free links
-      default_group.links.create(user: self, title: 'Change this', url: '', category: 'free') while self.links.count < 5
-      
-      social_group = Group.create(name: "My Social Media")
-      social_group.links.create(
-        category: 'social',
-        icon: 'twitter',
-        icon_style: 'brands',
-        position: '6',
-        title: 'Twitter',
-        url: 'twitter.com/your_username',
-        user: self,
-      )
-      social_group.links.create(
-        category: 'social',
-        icon: 'whatsapp',
-        icon_style: 'brands',
-        position: '7',
-        title: 'Whatsapp',
-        url: 'wa.me/60123456789',
-        user: self,
-      )
-      social_group.links.create(
-        category: 'social',
-        icon: 'facebook',
-        icon_style: 'brands',
-        position: '8',
-        title: 'Facebook',
-        url: 'facebook.com/your_username',
-        user: self,
-      )
-      social_group.links.create(
-        category: 'social',
-        icon: 'instagram',
-        icon_style: 'brands',
-        position: '9',
-        title: 'Instagram',
-        url: 'instagram.com/your_username',
-        user: self,
-      )
-      social_group.links.create(
-        category: 'social',
-        icon: 'linkedin',
-        icon_style: 'brands',
-        position: '10',
-        title: 'LinkedIn',
-        url: 'linkedin.com/in/your_username',
-        user: self,
-      )
-    end
-  end
-
-  def generate_qr_code
-    qrcode = RQRCode::QRCode.new("#{ENV['APP_URL']}/#{self.slug}")
-
-    # NOTE: showing with default options specified explicitly
-    qr_png = qrcode.as_png(
-      bit_depth: 1,
-      border_modules: 4,
-      color_mode: ChunkyPNG::COLOR_GRAYSCALE,
-      color: "black",
-      file: nil,
-      fill: "white",
-      module_px_size: 6,
-      resize_exactly_to: false,
-      resize_gte_to: false,
-      size: 120
-    )
-
-    self.qr_code.attach(
-      io: StringIO.new(qr_png.to_s),
-      filename: "user-#{self.id}-qrcode.png",
-      content_type: "image/png"
-    )
   end
 end

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,0 +1,5 @@
+class ApplicationService
+  def self.call(*args, &block)
+    new(*args, &block).call
+  end
+end

--- a/app/services/generate_links_for_new_user.rb
+++ b/app/services/generate_links_for_new_user.rb
@@ -1,0 +1,76 @@
+class GenerateLinksForNewUser
+  attr_reader :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    if @user.links.count == 0
+      # Create default links group
+      default_group = Group.create(name: "My Links", user_id: @user.id)
+      # Creates 5 free links
+      Link.create(
+        user_id: @user.id, 
+        title: 'Change this', 
+        url: '', 
+        category: 'free',
+        group_id: default_group.id
+      ) while @user.links.count < 5
+      
+      # Create social links group
+      social_group = Group.create(name: "My Social Media", user_id: @user.id)
+      # Creates 5 social links
+      Link.create(
+        group_id: social_group.id,
+        category: 'social',
+        icon: 'twitter',
+        icon_style: 'brands',
+        position: '6',
+        title: 'Twitter',
+        url: 'twitter.com/your_username',
+        user_id: @user.id
+      )
+      Link.create(
+        group_id: social_group.id,
+        category: 'social',
+        icon: 'whatsapp',
+        icon_style: 'brands',
+        position: '7',
+        title: 'Whatsapp',
+        url: 'wa.me/60123456789',
+        user_id: @user.id
+      )
+      Link.create(
+        group_id: social_group.id,
+        category: 'social',
+        icon: 'facebook',
+        icon_style: 'brands',
+        position: '8',
+        title: 'Facebook',
+        url: 'facebook.com/your_username',
+        user_id: @user.id
+      )
+      Link.create(
+        group_id: social_group.id,
+        category: 'social',
+        icon: 'instagram',
+        icon_style: 'brands',
+        position: '9',
+        title: 'Instagram',
+        url: 'instagram.com/your_username',
+        user_id: @user.id
+      )
+      Link.create(
+        group_id: social_group.id,
+        category: 'social',
+        icon: 'linkedin',
+        icon_style: 'brands',
+        position: '10',
+        title: 'LinkedIn',
+        url: 'linkedin.com/in/your_username',
+        user_id: @user.id
+      )
+    end
+  end
+end

--- a/app/services/generate_qr_code_for_user.rb
+++ b/app/services/generate_qr_code_for_user.rb
@@ -1,0 +1,31 @@
+class GenerateQrCodeForUser
+  attr_reader :user
+  
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    qrcode = RQRCode::QRCode.new("#{ENV['APP_URL']}/#{@user.slug}")
+
+    # NOTE: showing with default options specified explicitly
+    qr_png = qrcode.as_png(
+      bit_depth: 1,
+      border_modules: 4,
+      color_mode: ChunkyPNG::COLOR_GRAYSCALE,
+      color: "black",
+      file: nil,
+      fill: "white",
+      module_px_size: 6,
+      resize_exactly_to: false,
+      resize_gte_to: false,
+      size: 120
+    )
+
+    @user.qr_code.attach(
+      io: StringIO.new(qr_png.to_s),
+      filename: "user-#{@user.id}-qrcode.png",
+      content_type: "image/png"
+    )
+  end
+end


### PR DESCRIPTION
Seems like during google oauth sign up, a `create` method was invoked causing the sign up process to fail. This attempts to fix that error.