### PR TITLE
Disable shortlink and qr button on public navbar.

### DIFF
--- a/app/controllers/short_links_controller.rb
+++ b/app/controllers/short_links_controller.rb
@@ -17,10 +17,11 @@ class ShortLinksController < ApplicationController
   end
 
   def free
-    unless user_signed_in?
-      @show_checkbox_recaptcha = true
-    end
-    @short_link = ShortLink.new
+    redirect_to "/"
+    # unless user_signed_in?
+    #   @show_checkbox_recaptcha = true
+    # end
+    # @short_link = ShortLink.new
   end
 
   def create

--- a/app/views/layouts/_navbar_public.html.erb
+++ b/app/views/layouts/_navbar_public.html.erb
@@ -21,12 +21,12 @@
       <% unless user_signed_in? %>
         <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
           <li class="me-lg-2 mb-3 mb-lg-0">
-            <%= link_to free_short_links_path, class: "btn btn-warning navbar-btn shadow w-100" do %>
+            <%= link_to free_short_links_path, class: "btn btn-warning navbar-btn shadow w-100 disabled" do %>
               <i class="fas fa-wand-magic-sparkles me-2"></i>Shorten a Link
             <% end %>
           </li>
           <li class="me-lg-2 mb-3 mb-lg-0">
-            <%= link_to new_qr_code_path, class: "btn btn-success navbar-btn shadow w-100" do %>
+            <%= link_to new_qr_code_path, class: "btn btn-success navbar-btn shadow w-100 disabled" do %>
               <i class="fas fa-qrcode me-2"></i>Create a QR Code
             <% end %>
           </li>


### PR DESCRIPTION
Temporarily disable the entry points for public to create shortcodes and qr codes until recaptcha is properly configured. 